### PR TITLE
ddply() instead of mcdpply() in points_to_lines() function

### DIFF
--- a/R/points.R
+++ b/R/points.R
@@ -87,7 +87,7 @@ points_to_lines = function(points, group_id) {
         lines = points[, c("eid", coords)]
     )
     # Add NA row to indicate line end
-    lines$lines = mcddply(lines$lines, .(eid), function(line) {
+    lines$lines = ddply(lines$lines, .(eid), function(line) {
         return(rbind(line, c(line$eid[1], NA,NA)))
     })
     lines$lines$sid = 1


### PR DESCRIPTION
On second thought and some performance testing it seems better to have this function single core.
If needed, parallelization can now be done over multiple files.