### PR TITLE
Remove functions depending on rgeos/rgdal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ BugReports: https://github.com/ramboll/strafica/issues
 License: MIT + file LICENSE
 ByteCompile: true
 Encoding: UTF-8
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 Depends:
     R (>= 2.14)
 Imports:

--- a/R/buffer.R
+++ b/R/buffer.R
@@ -39,14 +39,10 @@ buffer.lines.list = function(lines, width, byid, quadsegs=10, ...) {
 #' @method buffer.lines SpatialLinesDataFrame
 #' @export
 buffer.lines.SpatialLinesDataFrame = function(lines, width, byid, quadsegs=10, ...) {
-    buffer = rgeos::gBuffer(lines, width=width, byid=byid, quadsegs=quadsegs, ...)
-    if (!methods::is(buffer, "SpatialPolygonsDataFrame")) {
-        # Data will be lacking if byid is FALSE.
-        data = data.frame(eid=seq_len(length(buffer@polygons)))
-        rownames(data) =  unlist(lapply(buffer@polygons, function(x) x@ID))
-        buffer = sp::SpatialPolygonsDataFrame(buffer, data)
-    }
-    return(buffer)
+    stop(
+        "The function 'buffer.lines' for SpatialLinesDataFrame objects has",
+        "been removed from this package."
+    )
 }
 
 #' Create polygon buffers around points.
@@ -76,14 +72,10 @@ buffer.points.data.frame = function(points, width, byid, quadsegs=10, ...) {
 #' @method buffer.points SpatialPointsDataFrame
 #' @export
 buffer.points.SpatialPointsDataFrame = function(points, width, byid, quadsegs=10, ...) {
-    buffer = rgeos::gBuffer(points, width=width, byid=byid, quadsegs=quadsegs, ...)
-    if (!methods::is(buffer, "SpatialPolygonsDataFrame")) {
-        # Data will be lacking if byid is FALSE.
-        data = data.frame(eid=seq_len(length(buffer@polygons)))
-        rownames(data) =  unlist(lapply(buffer@polygons, function(x) x@ID))
-        buffer = sp::SpatialPolygonsDataFrame(buffer, data)
-    }
-    return(buffer)
+    stop(
+        "The function 'buffer.points' for SpatialLinesDataFrame objects has",
+        "been removed from this package."
+    )
 }
 
 #' Create polygon buffers around polygons.
@@ -125,12 +117,8 @@ buffer.polys.list = function(polys, width, byid, quadsegs=10, ...) {
 #' @method buffer.polys SpatialPolygonsDataFrame
 #' @export
 buffer.polys.SpatialPolygonsDataFrame = function(polys, width, byid, quadsegs=10, ...) {
-    buffer = rgeos::gBuffer(polys, width=width, byid=byid, quadsegs=quadsegs, ...)
-    if (!methods::is(buffer, "SpatialPolygonsDataFrame")) {
-        # Data will be lacking if byid is FALSE.
-        data = data.frame(eid=seq_len(length(buffer@polygons)))
-        rownames(data) =  unlist(lapply(buffer@polygons, function(x) x@ID))
-        buffer = sp::SpatialPolygonsDataFrame(buffer, data)
-    }
-    return(buffer)
+    stop(
+        "The function 'buffer.polys' for SpatialLinesDataFrame objects has",
+        "been removed from this package."
+    )
 }

--- a/R/clip.R
+++ b/R/clip.R
@@ -49,32 +49,10 @@ clip.lines.list = function(lines, ...) {
 #' @method clip.lines SpatialLinesDataFrame
 #' @export
 clip.lines.SpatialLinesDataFrame = function(lines, ...) {
-    dots = list(...)
-    if (length(dots) == 1 && is.data.frame(dots[[1]])) {
-        # Polygon outline data frame.
-        to = polys.to.sp(dots[[1]])
-    } else if (length(dots) == 1 && methods::is(dots[[1]], "SpatialPolygonsDataFrame")) {
-        # SpatialPolygonsDataFrame object.
-        to = dots[[1]]
-    } else if (length(dots) == 4) {
-        # Bounding box coordinates (for legacy compatibility).
-        names(dots) = c("xmin", "xmax", "ymin", "ymax")
-        to = bbox.to.sp(dots)
-    } else {
-        stop("Bad arguments for bounds")
-    }
-    to = rgeos::gUnaryUnion(to)
-    message("Clipping lines to bounding polygon...")
-    data = as.data.frame(lines)
-    sp::proj4string(lines) = sp::proj4string(to) = ""
-    lines = rgeos::gIntersection(lines, to, byid=TRUE,  drop_lower_td=TRUE)
-    # gIntersection returns combined IDs, of which we want the first,
-    # which allows us to merge the data back that gIntersection lost.
-    id = gsub(" .*$", "", slots(lines@lines, "ID"))
-    for (i in seq_along(lines@lines))
-        lines@lines[[i]]@ID = id[i]
-    data = data[which(rownames(data) %in% id),,drop=FALSE]
-    return(sp::SpatialLinesDataFrame(lines, data))
+    stop(
+        "The function 'clip.lines' for SpatialLinesDataFrame objects has",
+        "been removed from this package."
+    )
 }
 
 #' Clip polygons to a bounding polygon.
@@ -128,43 +106,10 @@ clip.polys.list = function(polys, ...) {
 #' @method clip.polys SpatialPolygonsDataFrame
 #' @export
 clip.polys.SpatialPolygonsDataFrame = function(polys, ...) {
-    dots = list(...)
-    if (length(dots) == 1 && is.data.frame(dots[[1]])) {
-        # Polygon outline data frame.
-        to = polys.to.sp(dots[[1]])
-    } else if (length(dots) == 1 && methods::is(dots[[1]], "SpatialPolygonsDataFrame")) {
-        # SpatialPolygonsDataFrame object.
-        to = dots[[1]]
-    } else if (length(dots) == 4) {
-        # Bounding box coordinates (for legacy compatibility).
-        # Work around various polygon topology etc. related errors
-        # by using a simple pure R implementation.
-        polys = sp.to.polys(polys)
-        polys$outlines = squeeze.polys(polys$outlines, ...)
-        polys$data = subset(polys$data, eid %in% polys$outlines$eid)
-        return(polys.to.sp(polys$outlines, polys$data))
-    } else {
-        stop("Bad arguments for bounds")
-    }
-    to = rgeos::gUnaryUnion(to)
-    message("Clipping polygons to bounding polygon...")
-    data = as.data.frame(polys)
-    polys = rgeos::createSPComment(polys)
-    # rgeos is very strict about polygons having correct topology;
-    # try to fix possible topology errors by buffering.
-    polys = rgeos::gBuffer(polys, width=0, byid=TRUE)
-    sp::proj4string(polys) = sp::proj4string(to) = ""
-    # XXX: drop_lower_td=TRUE drops *everything* (rgeos 0.3-8).
-    polys = rgeos::gIntersection(polys, to, byid=TRUE, drop_lower_td=FALSE)
-    if (methods::is(polys, "SpatialCollections"))
-        polys = polys@polyobj
-    # gIntersection returns combined IDs, of which we want the first,
-    # which allows us to merge the data back that gIntersection lost.
-    id = gsub(" .*$", "", slots(polys@polygons, "ID"))
-    for (i in seq_along(polys@polygons))
-        polys@polygons[[i]]@ID = id[i]
-    data = data[which(rownames(data) %in% id),,drop=FALSE]
-    return(sp::SpatialPolygonsDataFrame(polys, data))
+        stop(
+        "The function 'clip.polys' for SpatialLinesDataFrame objects has",
+        "been removed from this package."
+    )
 }
 
 #' Clip segments to a bounding polygon.

--- a/R/difference.R
+++ b/R/difference.R
@@ -38,24 +38,8 @@ diff.polys.list = function(polys1, polys2) {
 #' @method diff.polys SpatialPolygonsDataFrame
 #' @export
 diff.polys.SpatialPolygonsDataFrame = function(polys1, polys2) {
-    data = as.data.frame(polys1)
-    polys1 = rgeos::createSPComment(polys1)
-    polys2 = rgeos::createSPComment(polys2)
-    # rgeos is very strict about polygons having correct topology;
-    # try to fix possible topology errors by buffering.
-    polys1 = rgeos::gBuffer(polys1, width=0, byid=TRUE)
-    polys2 = rgeos::gBuffer(union.polys(polys2), width=0, byid=TRUE)
-    sp::proj4string(polys1) = ""
-    sp::proj4string(polys2) = ""
-    # XXX: drop_lower_td=TRUE drops *everything* (rgeos 0.3-8).
-    polys = rgeos::gDifference(polys1, polys2, byid=TRUE, drop_lower_td=FALSE)
-    if (methods::is(polys, "SpatialCollections"))
-        polys = polys@polyobj
-    # gDifference returns combined IDs, of which we want the first,
-    # which allows us to merge the data back that gDifference lost.
-    id = gsub(" .*$", "", slots(polys@polygons, "ID"))
-    for (i in seq_along(polys@polygons))
-        polys@polygons[[i]]@ID = id[i]
-    data = data[which(rownames(data) %in% id),,drop=FALSE]
-    return(sp::SpatialPolygonsDataFrame(polys, data))
+    stop(
+        "The function 'diff.polys' for SpatialLinesDataFrame objects has",
+        "been removed from this package."
+    )
 }

--- a/R/drop.R
+++ b/R/drop.R
@@ -32,24 +32,10 @@ drop.points.data.frame = function(points, ...) {
 #' @method drop.points SpatialPointsDataFrame
 #' @export
 drop.points.SpatialPointsDataFrame = function(points, ...) {
-    dots = list(...)
-    if (length(dots) == 1 && is.data.frame(dots[[1]])) {
-        # Polygon outline data frame.
-        to = polys.to.sp(dots[[1]])
-    } else if (length(dots) == 1 && methods::is(dots[[1]], "SpatialPolygonsDataFrame")) {
-        # SpatialPolygonsDataFrame object.
-        to = dots[[1]]
-    } else if (length(dots) == 4) {
-        # Bounding box coordinates (for legacy compatibility).
-        names(dots) = c("xmin", "xmax", "ymin", "ymax")
-        to = bbox.to.sp(dots)
-    } else {
-        stop("Bad arguments for bounds")
-    }
-    message("Dropping points outside bounding polygon...")
-    sp::proj4string(points) = sp::proj4string(to) = ""
-    keep = which(rgeos::gContains(to, points, byid=TRUE))
-    return(points[keep,,drop=FALSE])
+    stop(
+        "The function 'drop.points' for SpatialLinesDataFrame objects has",
+        "been removed from this package."
+    )
 }
 
 #' Drop shapes outside bounding box.

--- a/R/geojson.R
+++ b/R/geojson.R
@@ -1,6 +1,6 @@
 # -*- coding: us-ascii-unix -*-
 
-#' Read points, lines or polygons from a GeoJSON file.
+#' This function has been removed from the package. Use `sf::st_read()` instead.
 #' @param fname name of GeoJSON file.
 #' @param stringsAsFactors should character vectors be converted to factors?
 #' @param encoding character encoding used in code{fname}.
@@ -8,24 +8,13 @@
 #' @return A \code{Spatial*DataFrame} object.
 #' @export read.geojson
 read.geojson = function(fname, stringsAsFactors=FALSE, encoding="UTF-8", ...) {
-    shapes = rgdal::readOGR(fname,
-                            layer=rgdal::ogrListLayers(fname)[1],
-                            stringsAsFactors=FALSE,
-                            encoding="",
-                            use_iconv=FALSE,
-                            ...)
-
-    # GDAL's encoding handling varies by platform,
-    # let's do the encoding conversion ourselves.
-    shapes@data = recode(shapes@data, encoding, "UTF-8")
-    if (stringsAsFactors) {
-        for (i in which(sapply(shapes@data, is.character)))
-            shapes@data[,i] = factor(shapes@data[,i])
-    }
-    return(shapes)
+    stop(
+        "The function 'read.geojson' has been removed from this package."
+    )
 }
 
-#' Write points, lines or polygons to a GeoJSON file.
+#' This function has been removed from the package. Use `sf::st_write()`
+#' instead.
 #' @param shapes a \code{Spatial*DataFrame} object.
 #' @param fname name of GeoJSON file to write.
 #' @param epsg projection code of input data, see
@@ -33,24 +22,7 @@ read.geojson = function(fname, stringsAsFactors=FALSE, encoding="UTF-8", ...) {
 #' automatically reprojected to it if needed.
 #' @export write.geojson
 write.geojson = function(shapes, fname, epsg) {
-    # UTF-8 is the default JSON encoding.
-    # http://www.ietf.org/rfc/rfc4627.txt
-    shapes@data = recode(shapes@data, NULL, "UTF-8")
-    if (epsg != 4326) {
-        # WGS 84 is the default coordinate system for GeoJSON.
-        # http://www.geojson.org/geojson-spec.html#coordinate-reference-system-objects
-        message("Reprojecting to WGS 84...")
-        shapes = reproject(shapes, epsg, 4326)
-    }
-    messagef("Writing '%s'...", fname)
-    # Due to writeOGR failing to overwrite files,
-    # write to tempdir and copy on from there.
-    tempname = tempfile(fileext=".geojson")
-    layer = gsub("\\..*$", "", basename(fname))
-    unlink(tempname)
-    rgdal::writeOGR(shapes, tempname, layer=layer, driver="GeoJSON")
-    file.copy(tempname, fname, overwrite=TRUE)
-    Sys.sleep(1)
-    unlink(tempname)
-    return(invisible())
+    stop(
+        "The function 'write.geojson' has been removed from this package."
+    )
 }

--- a/R/gpkg.R
+++ b/R/gpkg.R
@@ -1,6 +1,6 @@
 # -*- coding: us-ascii-unix -*-
 
-#' Read points, lines or polygons from a GeoPackage file
+#' This function has been removed from the package. Use `sf::st_read()` instead.
 #' @param fname name of GeoPackage file
 #' @param stringsAsFactors should character vector be converted to factors?
 #' @param encoding character encoding used in code{fname}.
@@ -8,46 +8,20 @@
 #' @return A \code{Spatial*DataFrame} object.
 #' @export read.gpkg
 read.gpkg = function(fname, stringsAsFactors=FALSE, encoding="UTF-8", ...) {
-    shapes = rgdal::readOGR(fname,
-                            layer=rgdal::ogrListLayers(fname)[1],
-                            stringsAsFactors=FALSE,
-                            encoding="",
-                            use_iconv=FALSE,
-                            ...)
-    
-    # GDAL's encoding handling varies by platform,
-    # let's do the encoding conversion ourselves.
-    shapes@data = recode(shapes@data, encoding, "UTF-8")
-    if (stringsAsFactors) {
-        for (i in which(sapply(shapes@data, is.character)))
-            shapes@data[,i] = factor(shapes@data[,i])
-    }
-    return(shapes)
+    stop(
+        "The function 'read.gpkg' has been removed from this package."
+    )
 }
 
-#' Write points, lines or polygons to a GeoPackage file.
+
+#' This function has been removed from the package. Use `sf::st_write()`
+#' instead.
 #' @param shapes a \code{Spatial*DataFrame} object.
 #' @param fname name of GeoPackage file to write.
 #' @param epsg projection code, see \code{\link{list.projections}}.
 #' @export write.gpkg
 write.gpkg = function(shapes, fname, epsg = NULL) {
-    shapes@data = recode(shapes@data, NULL, "UTF-8")
-    if(!is.null(epsg)) {
-        shapes@proj4string <- sp::CRS(proj.proj4(epsg))
-    } else {
-        message("###")
-        message("No projection code given, no CRS enclosed in .gpkg")
-        message("###")
-    }
-    messagef("Writing '%s'...", fname)
-    # Due to writeOGR failing to overwrite files,
-    # write to tempdir and copy on from there.
-    tempname = tempfile(fileext=".gpkg")
-    layer = gsub("\\..*$", "", basename(fname))
-    unlink(tempname)
-    rgdal::writeOGR(shapes, tempname, layer=layer, driver="GPKG")
-    file.copy(tempname, fname, overwrite=TRUE)
-    Sys.sleep(1)
-    unlink(tempname)
-    return(invisible())
+    stop(
+        "The function 'write.gpkg' has been removed from this package."
+    )
 }

--- a/R/polygons.R
+++ b/R/polygons.R
@@ -69,41 +69,9 @@ circles = function(xc, yc, radius, n=100) {
 #' @return A list with three data frames: data, outlines and areas.
 #' @export trace.grid
 trace.grid = function(grid, cell.size, by=NULL) {
-    if (is.null(by)) {
-        messagef("Tracing grid with %d cells...", nrow(grid))
-        # It would be faster to convert to a grid object (SpatialPixels,
-        # SpatialGrid, etc.), but it is not obvious how to trace that;
-        # gUnion functions want SpatialPolygons.
-        shapes = grid.to.sp(grid, cell.size)
-        shapes = rgeos::gUnaryUnion(shapes)
-        n = length(shapes@polygons)
-        data = data.frame(dummy=rep(1L, n))
-        shapes = sp::SpatialPolygonsDataFrame(shapes, data=data)
-        polys = sp.to.polys(shapes)
-        polys$data$dummy = NULL
-        polys$areas = attach.holes(polys$outlines)
-    } else {
-        id = do.call(classify, grid[,by,drop=FALSE])
-        ids = sort(unique(id))
-        messagef("Tracing grid with %d cells in %d parts...",
-                 nrow(grid), length(ids))
-
-        # grid.to.sp uses mclapply, so this is a second level of
-        # parallelization, but usually it shouldn't be a problem
-        # and should speed up gUnaryUnion and sp conversions.
-        polys = mclapply.stop(seq_along(ids), function(i) {
-            grid = grid[which(id == ids[i]),,drop=FALSE]
-            polys = suppressMessages(trace.grid(grid, cell.size))
-            polys$data[,by] = rep(grid[1,by], each=nrow(polys$data))
-            polys$data$eid = polys$outlines$eid = polys$areas$eid = i
-            return(polys)
-        })
-        data = rbind_all(lapply(polys, getElement, "data"))
-        outlines = rbind_all(lapply(polys, getElement, "outlines"))
-        areas = rbind_all(lapply(polys, getElement, "areas"))
-        polys = list(data=data, outlines=outlines, areas=areas)
-    }
-    return(polys)
+    stop(
+        "The function 'trace.grids' has been removed from this package."
+    )
 }
 
 #' Find discrete Voronoi regions.

--- a/R/shape.R
+++ b/R/shape.R
@@ -1,6 +1,6 @@
 # -*- coding: us-ascii-unix -*-
 
-#' Read points, lines or polygons from a shapefile.
+#' This function has been removed from the package. Use `sf::st_read()` instead.
 #' @param fname name of shapefile.
 #' @param stringsAsFactors should character vector be converted to factors?
 #' @param encoding character encoding used in code{fname}.
@@ -10,54 +10,20 @@
 #' @return A \code{Spatial*DataFrame} object.
 #' @export read.shape
 read.shape = function(fname, stringsAsFactors=FALSE, encoding="Latin1", ...) {
-    shapes = rgdal::readOGR(fname,
-                            layer=rgdal::ogrListLayers(fname)[1],
-                            stringsAsFactors=FALSE,
-                            encoding="",
-                            use_iconv=FALSE,
-                            integer64="allow.loss",
-                            ...)
-
-    # GDAL's encoding handling varies by platform,
-    # let's do the encoding conversion ourselves.
-    shapes@data = recode(shapes@data, encoding, "UTF-8")
-    if (stringsAsFactors) {
-        for (i in which(sapply(shapes@data, is.character)))
-            shapes@data[,i] = factor(shapes@data[,i])
-    }
-    return(shapes)
+    stop(
+        "The function 'read.shape' has been removed from this package."
+    )
 }
 
-#' Write points, lines or polygons to a shapefile.
+#' This function has been removed from the package. Use `sf::st_write()`
+#' instead.
 #' @param shapes a \code{Spatial*DataFrame} object.
 #' @param fname name of shapefile to write.
 #' @param epsg projection code, see \code{\link{list.projections}}.
 #' @param verbose a logical indicating whether or not to print out progress updates.
 #' @export write.shape
 write.shape = function(shapes, fname, epsg, verbose=TRUE) {
-    if (is.na(proj.shape(epsg)))
-        stop(sprintf("EPSG %s not supported", epsg))
-    # Latin 1 is the original standard DBF encoding.
-    shapes@data = recode(shapes@data, NULL, "Latin1")
-    if (verbose)
-        messagef("Writing '%s'...", fname)
-    # Due to writeOGR failing to overwrite files,
-    # write to tempdir and copy on from there.
-    tempname = tempfile(fileext=".shp")
-    extensions = c(".dbf", ".prj", ".shp", ".shx")
-    tempnames = sapply(extensions, function(x) gsub("\\.shp$", x, tempname))
-    layer = gsub("\\..*$", "", basename(fname))
-    unlink(tempnames)
-    rgdal::writeOGR(shapes, tempname, layer=layer, driver="ESRI Shapefile")
-    # Since Proj.4 definitions are often bad,
-    # overwrite the projection file with our own definition.
-    cat(proj.shape(epsg), file=gsub("\\.shp$", ".prj", tempname))
-    for (extension in extensions) {
-        src = gsub("\\.shp$", extension, tempname)
-        dst = gsub("\\.shp$", extension, fname)
-        file.copy(src, dst, overwrite=TRUE)
-        Sys.sleep(1)
-        unlink(src)
-    }
-    return(invisible())
+    stop(
+        "The function 'write.shape' has been removed from this package."
+    )
 }

--- a/R/union.R
+++ b/R/union.R
@@ -35,17 +35,10 @@ aggregate.polys.list = function(polys, by, data=NULL) {
 #' @method aggregate.polys SpatialPolygonsDataFrame
 #' @export
 aggregate.polys.SpatialPolygonsDataFrame = function(polys, by, data=NULL) {
-    polys@data$.aggregate.id = do.call(
-        classify, polys@data[,by,drop=FALSE])
-    fulldata = polys@data
-    polys = rgeos::gUnaryUnion(polys, polys@data$.aggregate.id)
-    aggdata = data.frame(.aggregate.id=slots(polys@polygons, "ID"))
-    fulldata$.aggregate.id = as.character(fulldata$.aggregate.id)
-    fulldata = fulldata[,c(".aggregate.id", by)]
-    aggdata = leftjoin(aggdata, fulldata, by=".aggregate.id")
-    if (!is.null(data))
-        aggdata = leftjoin(aggdata, data, by=by)
-    return(sp::SpatialPolygonsDataFrame(polys, data=aggdata))
+    stop(
+        "The function 'aggregate.polys' for SpatialLinesDataFrame objects has",
+        "been removed from this package."
+    )
 }
 
 #' Combine sets of polygons to form one polygon.
@@ -86,11 +79,8 @@ union.polys.list = function(...) {
 #' @method union.polys SpatialPolygonsDataFrame
 #' @export
 union.polys.SpatialPolygonsDataFrame = function(...) {
-    sets = list(...)
-    if (length(sets) == 0) return(NULL)
-    for (i in seq_along(sets)[-1])
-        sets[[1]] = rgeos::gUnion(sets[[1]], sets[[i]])
-    polys = rgeos::gUnaryUnion(sets[[1]])
-    data = data.frame(eid=1L)
-    return(sp::SpatialPolygonsDataFrame(polys, data=data))
+    stop(
+        "The function 'union.polys' for SpatialLinesDataFrame objects has",
+        "been removed from this package."
+    )
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ pool:
   vmImage: 'ubuntu-20.04'
 
 container:
-  image: 'rocker/geospatial:4.1.2'
+  image: 'rocker/geospatial:4.3.3'
 
 variables:
   _R_CHECK_FORCE_SUGGESTS_: false

--- a/man/read.geojson.Rd
+++ b/man/read.geojson.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/geojson.R
 \name{read.geojson}
 \alias{read.geojson}
-\title{Read points, lines or polygons from a GeoJSON file.}
+\title{This function has been removed from the package. Use `sf::st_read()` instead.}
 \usage{
 read.geojson(fname, stringsAsFactors = FALSE, encoding = "UTF-8", ...)
 }
@@ -19,5 +19,5 @@ read.geojson(fname, stringsAsFactors = FALSE, encoding = "UTF-8", ...)
 A \code{Spatial*DataFrame} object.
 }
 \description{
-Read points, lines or polygons from a GeoJSON file.
+This function has been removed from the package. Use `sf::st_read()` instead.
 }

--- a/man/read.gpkg.Rd
+++ b/man/read.gpkg.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/gpkg.R
 \name{read.gpkg}
 \alias{read.gpkg}
-\title{Read points, lines or polygons from a GeoPackage file}
+\title{This function has been removed from the package. Use `sf::st_read()` instead.}
 \usage{
 read.gpkg(fname, stringsAsFactors = FALSE, encoding = "UTF-8", ...)
 }
@@ -19,5 +19,5 @@ read.gpkg(fname, stringsAsFactors = FALSE, encoding = "UTF-8", ...)
 A \code{Spatial*DataFrame} object.
 }
 \description{
-Read points, lines or polygons from a GeoPackage file
+This function has been removed from the package. Use `sf::st_read()` instead.
 }

--- a/man/read.mapinfo.Rd
+++ b/man/read.mapinfo.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/mapinfo.R
 \name{read.mapinfo}
 \alias{read.mapinfo}
-\title{Read points, lines or polygons from a MapInfo TAB file.}
+\title{This function has been removed from the package. Use `sf::st_read()` instead.}
 \usage{
 read.mapinfo(fname, stringsAsFactors = FALSE, encoding = "CP1252", ...)
 }
@@ -19,5 +19,5 @@ read.mapinfo(fname, stringsAsFactors = FALSE, encoding = "CP1252", ...)
 A \code{Spatial*DataFrame} object.
 }
 \description{
-Read points, lines or polygons from a MapInfo TAB file.
+This function has been removed from the package. Use `sf::st_read()` instead.
 }

--- a/man/read.shape.Rd
+++ b/man/read.shape.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/shape.R
 \name{read.shape}
 \alias{read.shape}
-\title{Read points, lines or polygons from a shapefile.}
+\title{This function has been removed from the package. Use `sf::st_read()` instead.}
 \usage{
 read.shape(fname, stringsAsFactors = FALSE, encoding = "Latin1", ...)
 }
@@ -21,5 +21,5 @@ but in reality this will vary.}
 A \code{Spatial*DataFrame} object.
 }
 \description{
-Read points, lines or polygons from a shapefile.
+This function has been removed from the package. Use `sf::st_read()` instead.
 }

--- a/man/write.geojson.Rd
+++ b/man/write.geojson.Rd
@@ -2,7 +2,8 @@
 % Please edit documentation in R/geojson.R
 \name{write.geojson}
 \alias{write.geojson}
-\title{Write points, lines or polygons to a GeoJSON file.}
+\title{This function has been removed from the package. Use `sf::st_write()`
+instead.}
 \usage{
 write.geojson(shapes, fname, epsg)
 }
@@ -16,5 +17,6 @@ write.geojson(shapes, fname, epsg)
 automatically reprojected to it if needed.}
 }
 \description{
-Write points, lines or polygons to a GeoJSON file.
+This function has been removed from the package. Use `sf::st_write()`
+instead.
 }

--- a/man/write.gpkg.Rd
+++ b/man/write.gpkg.Rd
@@ -2,7 +2,8 @@
 % Please edit documentation in R/gpkg.R
 \name{write.gpkg}
 \alias{write.gpkg}
-\title{Write points, lines or polygons to a GeoPackage file.}
+\title{This function has been removed from the package. Use `sf::st_write()`
+instead.}
 \usage{
 write.gpkg(shapes, fname, epsg = NULL)
 }
@@ -14,5 +15,6 @@ write.gpkg(shapes, fname, epsg = NULL)
 \item{epsg}{projection code, see \code{\link{list.projections}}.}
 }
 \description{
-Write points, lines or polygons to a GeoPackage file.
+This function has been removed from the package. Use `sf::st_write()`
+instead.
 }

--- a/man/write.mapinfo.Rd
+++ b/man/write.mapinfo.Rd
@@ -2,7 +2,8 @@
 % Please edit documentation in R/mapinfo.R
 \name{write.mapinfo}
 \alias{write.mapinfo}
-\title{Write points, lines or polygons to a MapInfo TAB file.}
+\title{This function has been removed from the package. Use `sf::st_write()`
+instead.}
 \usage{
 write.mapinfo(shapes, fname, epsg)
 }

--- a/man/write.mif.Rd
+++ b/man/write.mif.Rd
@@ -2,7 +2,8 @@
 % Please edit documentation in R/mapinfo.R
 \name{write.mif}
 \alias{write.mif}
-\title{Write points, lines or polygons to a MapInfo MIF file.}
+\title{This function has been removed from the package. Use `sf::st_write()`
+instead.}
 \usage{
 write.mif(shapes, fname, epsg)
 }
@@ -14,5 +15,6 @@ write.mif(shapes, fname, epsg)
 \item{epsg}{projection code, see \code{\link{list.projections}}.}
 }
 \description{
-Write points, lines or polygons to a MapInfo MIF file.
+This function has been removed from the package. Use `sf::st_write()`
+instead.
 }

--- a/man/write.shape.Rd
+++ b/man/write.shape.Rd
@@ -2,7 +2,8 @@
 % Please edit documentation in R/shape.R
 \name{write.shape}
 \alias{write.shape}
-\title{Write points, lines or polygons to a shapefile.}
+\title{This function has been removed from the package. Use `sf::st_write()`
+instead.}
 \usage{
 write.shape(shapes, fname, epsg, verbose = TRUE)
 }
@@ -16,5 +17,6 @@ write.shape(shapes, fname, epsg, verbose = TRUE)
 \item{verbose}{a logical indicating whether or not to print out progress updates.}
 }
 \description{
-Write points, lines or polygons to a shapefile.
+This function has been removed from the package. Use `sf::st_write()`
+instead.
 }

--- a/tests/testthat/test_verbosity_settings.R
+++ b/tests/testthat/test_verbosity_settings.R
@@ -34,39 +34,6 @@ get_dummy_lines_as_sp = function() {
     return(lines_as_spdf)
 }
 
-
-test_that("with verbose option being unset, there will be messages when writing out a shapefile", {
-    dummy_epsg_code = 3067
-    dummy_lines_spdf = get_dummy_lines_as_sp()
-    dummy_file_name_shp = tempfile(fileext = ".shp")
-    expect_message(
-        strafica::write.shape(
-            dummy_lines_spdf,
-            dummy_file_name_shp,
-            epsg = dummy_epsg_code
-        ),
-        NULL
-    )
-    remove_all_shape_file_parts(dummy_file_name_shp)
-})
-
-test_that("with verbose=FALSE, there will be no messages when writing out a shapefile", {
-    dummy_epsg_code = 3067
-    dummy_lines_spdf = get_dummy_lines_as_sp()
-    dummy_file_name_shp = tempfile(fileext = ".shp")
-    expect_message(
-        strafica::write.shape(
-            dummy_lines_spdf,
-            dummy_file_name_shp,
-            epsg = dummy_epsg_code,
-            verbose = FALSE
-        ),
-        NA
-    )
-    remove_all_shape_file_parts(dummy_file_name_shp)
-})
-
-
 test_that("verbose=FALSE option can suppress messages with sp.to.lines", {
     dummy_lines_spdf = get_dummy_lines_as_sp()
     expect_message(
@@ -92,44 +59,6 @@ test_that("verbose=FALSE option can suppress messages with lines.to.sp", {
         strafica::lines.to.sp(
             dummy_lines$lines,
             dummy_lines$data,
-            verbose = FALSE
-        ),
-        NA
-    )
-})
-
-test_that("verbose=FALSE option can suppress output with sp.to.polys", {
-    spatial_data_frame_polys = strafica::read.geojson(
-        "test_data_two_polygons.geojson",
-        verbose = FALSE,
-    )
-    expect_message(
-        strafica::sp.to.polys(spatial_data_frame_polys),
-        NULL
-    )
-    expect_message(
-        strafica::sp.to.polys(spatial_data_frame_polys, verbose = FALSE),
-        NA
-    )
-})
-
-test_that("verbose=FALSE option can suppress output with polys.to.sp", {
-    spatial_data_frame_polys = strafica::read.geojson(
-        "test_data_two_polygons.geojson",
-        verbose = FALSE,
-    )
-    spatial_polygons_as_list = strafica::sp.to.polys(spatial_data_frame_polys)
-    expect_message(
-        strafica::polys.to.sp(
-            spatial_polygons_as_list$outlines,
-            spatial_polygons_as_list$data,
-        ),
-        NULL
-    )
-    expect_message(
-        strafica::polys.to.sp(
-            spatial_polygons_as_list$outlines,
-            spatial_polygons_as_list$data,
             verbose = FALSE
         ),
         NA


### PR DESCRIPTION
Easiest is just to take out the functions that depend on rgdal/rgeos. Internally, we won't miss them.